### PR TITLE
Fix: Contribute Button Link in Footer

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -60,7 +60,7 @@ const route = useRoute();
             </li>
             <li class="mb-4">
               <a
-                href="https://www.activepieces.com/docs/developers/overview"
+                href="https://www.activepieces.com/docs/build-pieces/building-pieces/overview"
                 class="hover:underline"
                 >Contribute</a
               >


### PR DESCRIPTION
**What does this PR do?**
Fixes the broken "Contribute" button in the footer that was leading to a 404 Page Not Found error.

**Changes Made**
Updated the link in `Footer.vue` to point to the contributing documentation page:
`https://www.activepieces.com/docs/build-pieces/building-pieces/overview`

Closes #99